### PR TITLE
feat: Enable setting index and error documents.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "swarm-gateway",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "main": "dist/index.js",
     "scripts": {
         "build": "tsc",

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,7 +28,7 @@ export function createApp(config: AppConfig, stampManager: StampManager): Applic
         res.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
         res.set(
             'Access-Control-Allow-Headers',
-            'Content-Type, Authorization, swarm-postage-batch-id, swarm-deferred-upload, swarm-index-document, swarm-error-document, swarm-collection'
+            'Content-Type, Authorization, swarm-postage-batch-id, swarm-postage-stamp, swarm-deferred-upload, swarm-index-document, swarm-error-document, swarm-collection'
         )
 
         if (req.method === 'OPTIONS') {

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,7 +28,7 @@ export function createApp(config: AppConfig, stampManager: StampManager): Applic
         res.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
         res.set(
             'Access-Control-Allow-Headers',
-            'Content-Type, Authorization, swarm-postage-batch-id, swarm-deferred-upload'
+            'Content-Type, Authorization, swarm-postage-batch-id, swarm-deferred-upload, swarm-index-document, swarm-error-document'
         )
 
         if (req.method === 'OPTIONS') {

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,7 +28,7 @@ export function createApp(config: AppConfig, stampManager: StampManager): Applic
         res.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
         res.set(
             'Access-Control-Allow-Headers',
-            'Content-Type, Authorization, swarm-postage-batch-id, swarm-deferred-upload, swarm-index-document, swarm-error-document'
+            'Content-Type, Authorization, swarm-postage-batch-id, swarm-deferred-upload, swarm-index-document, swarm-error-document, swarm-collection'
         )
 
         if (req.method === 'OPTIONS') {


### PR DESCRIPTION
I'm working on static site hosting using Swarm and I noticed not having these headers listed as allowed is causing CORS errors when using bee.js: 

> Access to XMLHttpRequest at 'https://swarm.o8.is/bzz' from origin 'http://localhost:3000' has been blocked by CORS policy: Request header field swarm-error-document is not allowed by Access-Control-Allow-Headers in preflight response.

I understand why some of the other headers might not be allowed, but I think these would make a lot of sense and would enable some cool workflows. 

Thanks for your time! 