### PR TITLE
fix: Enable subdomain rewrites without MySQL configured.

### DIFF
--- a/src/bzz-link.ts
+++ b/src/bzz-link.ts
@@ -5,12 +5,17 @@ import { Rewrites, RewritesRow } from './database/Rewrites'
 export class NotEnabledError extends Error {}
 
 export async function subdomainToBzz(subdomain: string): Promise<string> {
-    const rewrite = await Cache.get<RewritesRow | null>('rewrites', Dates.minutes(1), async () =>
-        Rewrites.getOneOrNull({ subdomain })
-    )
-    if (rewrite) {
-        return rewrite.target
+    try {
+        const rewrite = await Cache.get<RewritesRow | null>('rewrites', Dates.minutes(1), async () =>
+            Rewrites.getOneOrNull({ subdomain })
+        )
+        if (rewrite) {
+            return rewrite.target
+        }
+    } catch (error) {
+        // Database not configured or query failed
     }
+
     try {
         return new Reference(subdomain).toHex()
     } catch (e) {


### PR DESCRIPTION
I'm running a stateless gateway, and I'm running into an issue where the sub-domain rewrites just flat out fail and request: 

```
[gateway]: [31mtime="2025-11-19T14:13:17.705Z" level="error" msg="proxy failed" code="ECONNREFUSED" errno="undefined" sql="undefined" sqlState="undefined" sqlMessage="undefined" stack="Error\n    at PromisePool.query (/app/node_modules/mysql2/lib/promise/pool.js:36:22)\n    at runQuery (/app/dist/database/Database.js:36:17)\n    at getOnlyRowOrNull (/app/dist/database/Database.js:42:36)\n    at Object.getOneOrNull (/app/dist/database/Rewrites.js:12:48)\n    at /app/dist/bzz-link.js:12:129\n    at Object.getCached [as get] (/app/node_modules/cafe-utility/index.js:1477:18)\n    at subdomainToBzz (/app/dist/bzz-link.js:12:48)\n    at /app/dist/proxy.js:38:64\n    at Layer.handle [as handle_request] (/app/node_modules/express/lib/router/layer.js:95:5)\n    at trim_prefix (/app/node_modules/express/lib/router/index.js:328:13)"[39m
```

In other places the gateway fails more gracefully, and I think this should match that behavior. 